### PR TITLE
Implement CSFloat price checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # CSFloatPriceChecker
-A script usable by anyone that checks the price of the user's input by checking against the CSFloat Database thanks to their API. everyone can use it by downloading the script and launching the secret.py where the user will be prompted to input his secret key so he can be able to utilize the script
+
+A script that checks the price of a Steam item by querying the CSFloat API.
+
+## Usage
+
+1. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the script:
+   ```bash
+   python secret.py
+   ```
+3. Enter your CSFloat API key and the name of the item when prompted.
+
+The script will display the lowest price returned by the API.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/secret.py
+++ b/secret.py
@@ -1,0 +1,36 @@
+import requests
+
+
+def main():
+    key = input("Enter your CSFloat API key: ").strip()
+    if not key:
+        print("API key is required.")
+        return
+
+    item_name = input("Enter the item name to check price for: ").strip()
+    if not item_name:
+        print("Item name is required.")
+        return
+
+    url = "https://csfloat.com/api/v1/listings"
+    params = {
+        "market_hash_name": item_name,
+        "key": key,
+    }
+
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+
+        price = data.get("lowest_price")
+        if price is None:
+            print(f"No price information found for '{item_name}'.")
+        else:
+            print(f"Lowest price for '{item_name}' is {price}.")
+    except requests.RequestException as exc:
+        print(f"Failed to fetch price: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script that queries the CSFloat API for item prices
- document how to use the script
- specify `requests` dependency

## Testing
- `python3 -m py_compile secret.py`


------
https://chatgpt.com/codex/tasks/task_e_68890e6edc0c832cb6e868d7994dd7c3