### PR TITLE
Fix API data handling and clarify auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A script that checks CSFloat Market listings with various filters.
    python csfloat_cli.py
    ```
 
-   The script stores your API key in `csfloat_config.json` and lets you search listings by item type, wear, float range and more. The key is sent using the `Authorization` header as required by the CSFloat API. All requests and responses are logged to `csfloat.log` for troubleshooting.
+   The script stores your API key in `csfloat_config.json` and lets you search listings by item type, wear, float range and more. The key is sent using the `Authorization: Bearer <token>` header as required by the CSFloat API. All requests and responses are logged to `csfloat.log` for troubleshooting.
 
 
 You can still run `secret.py` for a simple one-off price check.

--- a/secret.py
+++ b/secret.py
@@ -28,7 +28,7 @@ def main():
         "limit": 1,
         "sort_by": "lowest_price",
     }
-    headers = {"Authorization": key}
+    headers = {"Authorization": f"Bearer {key}"} if key else {}
 
     logger.info('Requesting single price: params=%s', params)
 
@@ -40,8 +40,8 @@ def main():
         data = response.json()
         if isinstance(data, list) and data:
             price = data[0].get("price")
-        elif isinstance(data, dict) and data.get("listings"):
-            price = data["listings"][0].get("price")
+        elif isinstance(data, dict) and data.get("data"):
+            price = data["data"][0].get("price")
         else:
             price = None
 


### PR DESCRIPTION
## Summary
- normalize wear tiers in item names and strip unsupported query params
- read listings from the `data` key returned by CSFloat
- use `Authorization: Bearer` for API calls
- show prices in dollars and guard against missing fields
- document the bearer header in the README

## Testing
- `python -m py_compile csfloat_cli.py secret.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a0ddcb708832ca47a5111aad7f3bc