### PR TITLE
Enable background price tracking with GUI progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Prices are shown in US dollars rather than cents for easier reading.
    python csfloat_cli.py
    ```
 
-   The script stores your API key in `csfloat_config.json` and lets you search listings by item type, wear, float range and more. It now also allows you to include or exclude auction listings from the results. The key is sent using the `Authorization` header as required by the CSFloat API. All requests and responses are logged to `csfloat.log` for troubleshooting.
+The script stores your API key in `csfloat_config.json` and lets you search listings by item type, wear, float range and more. It now also allows you to include or exclude auction listings from the results. The key is sent using the `Authorization` header as required by the CSFloat API. All requests and responses are logged to `csfloat.log` for troubleshooting.
+
+After showing search results you can opt in to background price tracking. If accepted, a small window opens that logs a new price check every minute and displays an indeterminate progress bar. Close the window or press the **Stop** button to end tracking. Data is appended to a `track_<item>.csv` file.
 
 
 You can still run `secret.py` for a simple one-off price check.


### PR DESCRIPTION
## Summary
- add tkinter-based progress window for background price tracking
- log each minute to a CSV file and allow stopping via the window
- ask user if they want to track prices every minute instead of entering hours
- document new behaviour in README

## Testing
- `python -m py_compile csfloat_cli.py secret.py`

------
https://chatgpt.com/codex/tasks/task_e_688b386b3bc4832cbdb03cd3580ab4d6