### PR TITLE
Fix auction detection and filtering

### DIFF
--- a/csfloat_cli.py
+++ b/csfloat_cli.py
@@ -317,6 +317,7 @@ def display_results(data):
             or item.get('auction') is True
             or item.get('listing_type') == 'auction'
             or item.get('sale_type') == 'auction'
+            or item.get('type') == 'auction'
         )
         time_left = (
             item.get('time_remaining')
@@ -324,7 +325,7 @@ def display_results(data):
             or item.get('auction_ends_at')
             or item.get('expires_at')
         )
-        auction_info = 'Auction' if is_auction else 'Listing'
+        auction_info = 'Auction' if is_auction else 'Buy now'
         if time_left:
             auction_info += f' (time left: {time_left})'
         print(f'{name} | {wear_name} | float={float_val} | price={price} | {auction_info}')
@@ -371,7 +372,10 @@ def main():
                 if name:
                     params['market_hash_name'] = name
                 include_auctions = prompt_include_auctions()
-                params['include_auctions'] = include_auctions
+                if not include_auctions:
+                    params['type'] = 'buy_now'
+                elif 'type' in params:
+                    params.pop('type')
                 if not search_options(params):
                     params = {}
                 break


### PR DESCRIPTION
## Summary
- improve detection of auction listings by checking the `type` field
- set `type=buy_now` when auctions are excluded
- label non-auction listings as `Buy now`

## Testing
- `python -m py_compile csfloat_cli.py secret.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688b3cb6f5e8832cb0b1f8e40e3f36f7