### PR TITLE
Improve sort selection

### DIFF
--- a/csfloat_cli.py
+++ b/csfloat_cli.py
@@ -154,9 +154,18 @@ def prompt_category():
 
 
 def prompt_sort_by() -> str | None:
-    print('Enter sort order (most_recent, lowest_price, lowest_float):')
-    sort_by = input('> ').strip()
-    return sort_by or None
+    options = ['most_recent', 'lowest_price', 'lowest_float']
+    print('Select sort order:')
+    for idx, opt in enumerate(options, 1):
+        print(f'{idx}. {opt}')
+    print('0. Cancel')
+    choice = input('> ').strip()
+    if choice == '0':
+        return None
+    if choice.isdigit() and 1 <= int(choice) <= len(options):
+        return options[int(choice) - 1]
+    print('Invalid selection.')
+    return None
 
 
 def prompt_include_auctions() -> bool:

--- a/csfloat_gui.py
+++ b/csfloat_gui.py
@@ -87,6 +87,7 @@ CATEGORY_CHOICES = {
     'StatTrak': 2,
     'Souvenir': 3,
 }
+SORT_OPTIONS = ['most_recent', 'lowest_price', 'lowest_float']
 
 
 def fuzzy_search_name(query: str, names: list, limit: int = 10) -> list:
@@ -272,7 +273,7 @@ class PriceCheckerGUI:
 
         tk.Label(win, text='Sort By:').grid(row=7, column=0, sticky='e')
         sort_var = tk.StringVar(value='most_recent')
-        ttk.Entry(win, textvariable=sort_var, width=20).grid(row=7, column=1, sticky='w')
+        ttk.Combobox(win, textvariable=sort_var, values=SORT_OPTIONS).grid(row=7, column=1, sticky='w')
 
         include_auctions_var = tk.BooleanVar(value=True)
         ttk.Checkbutton(win, text='Include Auctions', variable=include_auctions_var).grid(row=8, column=1, sticky='w')


### PR DESCRIPTION
## Summary
- make CLI sort prompt use numbered menu
- add dropdown for sorting in GUI

## Testing
- `python -m py_compile csfloat_cli.py csfloat_gui.py secret.py`

------
https://chatgpt.com/codex/tasks/task_e_688b57f55fdc832cb81d079b6830f392