### PR TITLE
Add open listing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,7 @@ The script stores your API key in `csfloat_config.json` and lets you search list
 
 After showing search results you can opt in to background price tracking. If accepted, a small window opens that logs a new price check every minute and displays an indeterminate progress bar. Close the window or press the **Stop** button to end tracking. Data is appended to a `track_<item>.csv` file.
 
+From the results window you can also open the selected listing in your web browser using the **Open Listing** button (or by double clicking a row).
+
 
 You can still run `secret.py` for a simple one-off price check.

--- a/csfloat_cli.py
+++ b/csfloat_cli.py
@@ -348,14 +348,17 @@ def display_results(data) -> None:
             auction_info = 'Auction' if is_auction else 'Buy now'
             if time_left:
                 auction_info += f' (time left: {time_left})'
-            print(f"{name} | {wear_name} | float={float_val} | price={price} | {auction_info}")
+            listing_id = item.get('id')
+            url = f"https://csfloat.com/item/{listing_id}" if listing_id else 'N/A'
+            print(f"{name} | {wear_name} | float={float_val} | price={price} | {auction_info} | {url}")
             logger.info(
-                'Result: %s | %s | float=%s | price=%s | %s',
+                'Result: %s | %s | float=%s | price=%s | %s | %s',
                 name,
                 wear_name,
                 float_val,
                 price,
                 auction_info,
+                url,
             )
 
         print(f"Page {page + 1}/{total_pages} - [n]ext, [p]revious, [f]irst, [l]ast, [q]uit")


### PR DESCRIPTION
## Summary
- add `webbrowser` for opening listings
- show listing URLs in CLI output
- allow opening listings from GUI results via new button or double click
- document listing link feature

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile csfloat_gui.py csfloat_cli.py secret.py`


------
https://chatgpt.com/codex/tasks/task_e_688b853e3f88832c8e01d8efdef68f2c