### PR TITLE
Improve GUI UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ This exposes the `csfloat-price` and `csfloat-price-gui` commands.
 
 The script stores your API key in `csfloat_config.json` and lets you search listings by item type, wear, float range and more. It now also allows you to include or exclude auction listings from the results. The key is sent using the `Authorization` header as required by the CSFloat API. All requests and responses are logged to `csfloat.log` for troubleshooting.
 
-After showing search results you can opt in to background price tracking. If accepted, a small window opens that logs a new price check every minute and displays an indeterminate progress bar. Close the window or press the **Stop** button to end tracking. Data is appended to a `track_<item>.csv` file.
+After showing search results you can opt in to background price tracking. If accepted, a small window opens that logs a new price check every minute. The window shows a small status label and an indeterminate progress bar. Click **Stop** to cancel tracking. Data is appended to a `track_<item>.csv` file.
+
+The GUI remembers your last used filters. The results table supports column sorting and a **Copy URL** button to quickly copy the selected listing's link. A status bar shows how many requests were made in the last minute and the time of the most recent refresh. If the API returns a rate limit response, a warning toast is displayed.
 
 From the results window you can also open the selected listing in your web browser using the **Open Listing** button (or by double clicking a row).
 


### PR DESCRIPTION
## Summary
- persist last used filters between sessions
- add status bar with rate info and refresh time
- show rate limit warnings and copy URL button
- track price window now has a status label
- update README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `pip install -e .`
- `python -m csfloat_price_checker.api <<'EOF'

EOF`

------
https://chatgpt.com/codex/tasks/task_e_688c2dd18e80832c87e488d844e9b1bd