### PR TITLE
Initialize status variable before building GUI

### DIFF
--- a/src/csfloat_price_checker/gui.py
+++ b/src/csfloat_price_checker/gui.py
@@ -283,9 +283,9 @@ class PriceCheckerGUI:
         self.tracked = load_tracked()
         self.active_tracks: dict[str, threading.Event] = {}
         self.style = ttk.Style()
+        self.status_var = tk.StringVar()
         self.build_main()
         self.last_refresh_time: str | None = None
-        self.status_var = tk.StringVar()
         self.update_status()
         try:
             self.root.attributes('-alpha', 0.0)


### PR DESCRIPTION
## Summary
- create `status_var` before calling `build_main` so widgets can reference it

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688d1c8e23b0832cb2dbcf90c1015051