### PR TITLE
Add GUI skin alerts with desktop notifications

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 ttkbootstrap==1.10.1
+plyer

--- a/src/csfloat_price_checker/notification.py
+++ b/src/csfloat_price_checker/notification.py
@@ -1,0 +1,37 @@
+"""Desktop notification helper for CSFloat price checker."""
+
+try:
+    from plyer import notification
+except Exception:  # pragma: no cover - plyer might not be available
+    notification = None
+
+
+def show_desktop_notification(skin_name: str, listing: dict) -> None:
+    """Show a desktop notification for a matching skin listing.
+
+    Parameters
+    ----------
+    skin_name: str
+        The name of the skin being alerted.
+    listing: dict
+        A dictionary containing at least ``price`` and ``float`` keys.
+    """
+    if notification is None:
+        return
+
+    price = listing.get("price")
+    flt = listing.get("float")
+    try:
+        price_text = f"${float(price):.2f}" if price is not None else "Unknown price"
+    except Exception:
+        price_text = str(price)
+    try:
+        float_text = f"{float(flt):.4f}" if flt is not None else "Unknown float"
+    except Exception:
+        float_text = str(flt)
+
+    notification.notify(
+        title="Skin Alert!",
+        message=f"{skin_name} found for {price_text} with float {float_text}",
+        timeout=10,
+    )


### PR DESCRIPTION
## Summary
- integrate plyer-based desktop notifications
- add alert tracking and configuration UI in GUI
- list, edit, and delete tracked skin alerts

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python -m py_compile src/csfloat_price_checker/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68946a5e2984832c807791498f187929