### PR TITLE
feat: add dual tracking modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ This exposes the `csfloat-price` and `csfloat-price-gui` commands.
 
 The script stores your API key in `csfloat_config.json` and lets you search listings by item type, wear, float range and more. It now also allows you to include or exclude auction listings from the results. The key is sent using the `Authorization` header as required by the CSFloat API. All requests and responses are logged to `csfloat.log` for troubleshooting.
 
-After showing search results you can opt in to background price tracking. If accepted, a small window opens that logs a new price check every minute. The window shows a small status label and an indeterminate progress bar. Click **Stop** to cancel tracking. Data is appended to a `track_<item>.csv` file.
+After showing search results you can opt in to tracking. Two modes are available:
+
+1. **Alerts** – get notified when a listing meets your price or float filters.
+2. **Price evolution** – log every listing's price and float over time to `tracked_logs/<item>.csv`.
+
+You can enable either or both modes. When price tracking is enabled a small window opens showing progress; click **Stop** to cancel.
 
 The GUI remembers your last used filters. The results table supports column sorting and a **Copy URL** button to quickly copy the selected listing's link. A status bar shows how many requests were made in the last minute and the time of the most recent refresh. If the API returns a rate limit response, a warning toast is displayed.
 


### PR DESCRIPTION
## Summary
- allow tracking searches for alerts and/or price evolution
- log all listing data to `tracked_logs` with price and float
- manage tracking states from tracked items view

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894b1fd7b84832c90365f25108ea88a