### PR TITLE
Add multi-skin price tracking groups with history graphing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ The script stores your API key in `csfloat_config.json` and lets you search list
 
 The GUI also offers a **Bulk Search** menu where you can configure multiple items, each with its own filters, and run all of the searches at once. Results for every item open in separate windows for easy comparison.
 
+### Price Groups
+
+Use **Price Groups** to track multiple skins at once. Create a group of skins, save it with a custom name and the application will display the lowest price for each skin along with the running total. Every refresh logs a timestamped price entry to a JSON file per skin. Select **View History** next to a skin to open a matplotlib chart showing how the price has evolved over time.
+
+Example history file:
+
+```json
+[
+  {"timestamp": "2024-01-01T12:00:00", "price": 123.45},
+  {"timestamp": "2024-01-01T13:00:00", "price": 120.00}
+]
+```
+
 After showing search results you can opt in to tracking. Two modes are available:
 
 1. **Alerts** – get notified when a listing meets your price or float filters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
     "requests",
     "ttkbootstrap>=1.10.1",
+    "matplotlib",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 ttkbootstrap==1.10.1
 plyer
+matplotlib


### PR DESCRIPTION
## Summary
- add Price Groups feature for tracking multiple skins at once and computing total lowest price
- log per-skin price history to JSON and display matplotlib graph via View History button
- document feature and add matplotlib dependency

## Testing
- `python -m py_compile src/csfloat_price_checker/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6895546ee090832c9aa4980095ffa6ac