### PR TITLE
Add bulk search summary and API helpers

### DIFF
--- a/src/csfloat_price_checker/api.py
+++ b/src/csfloat_price_checker/api.py
@@ -1,53 +1,181 @@
-"""Simple API helper used by the CLI and GUI."""
+"""API helpers for CSFloat price checking."""
 
 from __future__ import annotations
 
-import os
 import logging
-from typing import Optional
+import os
+import time
+from typing import Any, Optional
 
 import requests
 
-LOG_FILE = os.path.join(os.path.dirname(__file__), 'csfloat.log')
+LOG_FILE = os.path.join(os.path.dirname(__file__), "csfloat.log")
 logging.basicConfig(
     filename=LOG_FILE,
     level=logging.INFO,
-    format='%(asctime)s %(levelname)s:%(message)s'
+    format="%(asctime)s %(levelname)s:%(message)s",
 )
 logger = logging.getLogger(__name__)
 
 
-def get_lowest_price(api_key: str, item_name: str) -> Optional[float]:
-    """Return the lowest price for ``item_name`` in USD or ``None``."""
+# ---------------------------------------------------------------------------
+# Request / rate limit tracking
+# ---------------------------------------------------------------------------
+
+REQUEST_TIMES: list[float] = []
+API_RATE_LIMIT: int = 60
+RATE_LIMIT_HIT: bool = False
+
+
+def update_rate_limit(headers: dict) -> None:
+    """Update the global API rate limit from response headers."""
+    global API_RATE_LIMIT
+    try:
+        limit = int(headers.get("X-RateLimit-Limit", API_RATE_LIMIT))
+        if limit > 0:
+            API_RATE_LIMIT = limit
+    except (TypeError, ValueError):
+        pass
+
+
+def rate_limit_interval() -> float:
+    """Return the recommended delay between requests based on the limit."""
+    return 60.0 / API_RATE_LIMIT if API_RATE_LIMIT else 6.0
+
+
+def record_request() -> None:
+    """Record a request timestamp and prune entries older than a minute."""
+    now = time.time()
+    REQUEST_TIMES.append(now)
+    while REQUEST_TIMES and now - REQUEST_TIMES[0] > 60:
+        REQUEST_TIMES.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# Low level query helpers
+# ---------------------------------------------------------------------------
+
+def query_listings(api_key: str, params: dict) -> Optional[Any]:
+    """Query the CSFloat listings endpoint.
+
+    Parameters
+    ----------
+    api_key:
+        CSFloat API key.
+    params:
+        Parameters passed directly to the API.
+    """
+
     url = "https://csfloat.com/api/v1/listings"
-    params = {
-        "market_hash_name": item_name,
-        "limit": 1,
-        "sort_by": "lowest_price",
-    }
+    params = params.copy()
+    params.setdefault("limit", 50)
     headers = {"Authorization": api_key}
 
-    logger.info("Requesting single price: params=%s", params)
+    logger.info("Request params: %s", params)
 
     try:
-        response = requests.get(url, params=params, headers=headers, timeout=10)
-        logger.info("Response status: %s", response.status_code)
-        response.raise_for_status()
-        logger.info("Response body: %s", response.text[:200])
-        data = response.json()
-        if isinstance(data, list) and data:
-            price_cents = data[0].get("price")
-        elif isinstance(data, dict) and data.get("listings"):
-            price_cents = data["listings"][0].get("price")
-        else:
-            price_cents = None
-
-        if isinstance(price_cents, (int, float)):
-            return price_cents / 100
-        return None
+        resp = requests.get(url, params=params, headers=headers, timeout=10)
+        record_request()
+        update_rate_limit(resp.headers)
+        global RATE_LIMIT_HIT
+        RATE_LIMIT_HIT = resp.status_code == 429
+        logger.info("Response status: %s", resp.status_code)
+        if RATE_LIMIT_HIT:
+            return None
+        resp.raise_for_status()
+        logger.info("Response body: %s", resp.text[:200])
+        return resp.json()
     except requests.RequestException as exc:
-        logger.exception("Failed to fetch price: %s", exc)
+        logger.exception("Failed to query API: %s", exc)
         return None
+
+
+def fetch_lowest_listing(api_key: str, item_name: str, filters: dict) -> Optional[dict]:
+    """Return the lowest priced listing for ``item_name``.
+
+    Parameters
+    ----------
+    api_key:
+        CSFloat API key.
+    item_name:
+        Name of the item to search for.
+    filters:
+        Dictionary of additional query parameters and local flags. Supports an
+        ``include_auctions`` boolean which, when ``False``, removes auction
+        listings from the results.
+
+    Returns
+    -------
+    dict | None
+        A dictionary containing ``item``, ``price_usd``, ``url``,
+        ``listing_id`` and ``is_auction`` keys, or ``None`` if no listings are
+        found after applying filters.
+    """
+
+    params = filters.copy()
+    include_auctions = params.pop("include_auctions", True)
+    params["market_hash_name"] = item_name
+    if not include_auctions:
+        params["type"] = "buy_now"
+
+    data = query_listings(api_key, params)
+    if not data:
+        return None
+
+    listings = data.get("data") if isinstance(data, dict) else data
+    if not listings:
+        return None
+
+    min_float = params.get("min_float")
+    max_float = params.get("max_float")
+
+    candidates: list[tuple[float, dict, bool]] = []
+    for item in listings:
+        price_cents = item.get("price")
+        float_val = item.get("float", {}).get("float_value")
+        is_auction = (
+            item.get("is_auction")
+            or item.get("auction") is True
+            or item.get("listing_type") == "auction"
+            or item.get("sale_type") == "auction"
+            or item.get("type") == "auction"
+        )
+        if not include_auctions and is_auction:
+            continue
+        if isinstance(min_float, (int, float)) and (
+            float_val is None or float_val < min_float
+        ):
+            continue
+        if isinstance(max_float, (int, float)) and (
+            float_val is None or float_val > max_float
+        ):
+            continue
+        if isinstance(price_cents, (int, float)):
+            candidates.append((price_cents, item, is_auction))
+
+    if not candidates:
+        return None
+
+    price_cents, listing, is_auction = min(candidates, key=lambda x: x[0])
+    price_usd = round(price_cents / 100, 2)
+    listing_id = listing.get("id")
+    url = f"https://csfloat.com/item/{listing_id}" if listing_id else ""
+
+    return {
+        "item": item_name,
+        "price_usd": price_usd,
+        "url": url,
+        "listing_id": str(listing_id) if listing_id else "",
+        "is_auction": bool(is_auction),
+    }
+
+
+def get_lowest_price(api_key: str, item_name: str) -> Optional[float]:
+    """Return the lowest price for ``item_name`` in USD or ``None``."""
+    res = fetch_lowest_listing(api_key, item_name, {})
+    if res is None:
+        return None
+    return res.get("price_usd")
 
 
 def main() -> None:
@@ -71,3 +199,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/src/csfloat_price_checker/cli.py
+++ b/src/csfloat_price_checker/cli.py
@@ -8,7 +8,7 @@ import logging
 import queue
 import tkinter as tk
 from tkinter import ttk
-import requests
+from .api import query_listings
 
 LOG_FILE = os.path.join(os.path.dirname(__file__), 'csfloat.log')
 logging.basicConfig(
@@ -213,25 +213,6 @@ def search_options(params: dict) -> bool:
             return False
         else:
             print('Invalid option')
-
-
-def query_listings(key: str, params: dict):
-    """Query CSFloat listings endpoint with provided parameters."""
-    url = 'https://csfloat.com/api/v1/listings'
-    params = params.copy()
-    params.setdefault('limit', 50)
-    headers = {'Authorization': key}
-    logger.info('Request params: %s', params)
-    try:
-        resp = requests.get(url, params=params, headers=headers, timeout=10)
-        logger.info('Response status: %s', resp.status_code)
-        resp.raise_for_status()
-        logger.info('Response body: %s', resp.text[:200])
-        return resp.json()
-    except Exception as exc:
-        logger.exception('Failed to query API: %s', exc)
-        print(f'Failed to query API: {exc}')
-        return None
 
 
 def track_price(key: str, params: dict, name: str) -> None:


### PR DESCRIPTION
## Summary
- centralize CSFloat API helpers and add `fetch_lowest_listing`
- add bulk search summary with per-item minimums and grand total
- modernize tables with striped rows and theme-aware status bar

## Testing
- `python -m py_compile CSFloatPriceChecker/src/csfloat_price_checker/api.py CSFloatPriceChecker/src/csfloat_price_checker/gui.py CSFloatPriceChecker/src/csfloat_price_checker/cli.py`
- `PYTHONPATH=src python - <<'PY'
import os
from csfloat_price_checker.api import fetch_lowest_listing
api_key = os.getenv('CSFLOAT_API_KEY')
print('api_key present?', bool(api_key))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689621fa6470832c96570d0c8a0409b5