### PR TITLE
Add inventory pricing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ The script stores your API key in `csfloat_config.json` and lets you search list
 
 The GUI also offers a **Bulk Search** menu where you can configure multiple items, each with its own filters, and run all of the searches at once. Results for every item open in separate windows for easy comparison.
 
+### Pricing an inventory dump
+
+The CLI provides a **Price inventory from file** option. Supply a JSON file
+containing a Steam inventory dump (like the example in the issue) and the
+script will look up the lowest `buy now` price for each item while matching the
+item's wear. Badges, medals and other collectibles are ignored.
+
 ### Price Groups
 
 Use **Price Groups** to track multiple skins at once. Create a group of skins, save it with a custom name and the application will display the lowest price for each skin along with the running total. Every refresh logs a timestamped price entry to a JSON file per skin. Select **View History** next to a skin to open a matplotlib chart showing how the price has evolved over time.

--- a/src/csfloat_price_checker/cli.py
+++ b/src/csfloat_price_checker/cli.py
@@ -8,7 +8,9 @@ import logging
 import queue
 import tkinter as tk
 from tkinter import ttk
-from .api import query_listings
+
+from .api import query_listings, fetch_lowest_listing, rate_limit_interval
+from .inventory import parse_inventory
 
 LOG_FILE = os.path.join(os.path.dirname(__file__), 'csfloat.log')
 logging.basicConfig(
@@ -370,6 +372,7 @@ def main():
         print('1. Search listings')
         print('2. Replace API key')
         print('3. Delete API key')
+        print('4. Price inventory from file')
         print('0. Exit')
         action = input('> ').strip()
         if action == '1':
@@ -424,6 +427,37 @@ def main():
                 logger.info('API key deleted by user')
             else:
                 print('No API key stored.')
+        elif action == '4':
+            key = get_api_key(cfg)
+            if not key:
+                continue
+            path = input('Enter path to inventory JSON file: ').strip()
+            if not path or not os.path.exists(path):
+                print('File not found.')
+                continue
+            try:
+                with open(path, 'r', encoding='utf-8') as fh:
+                    inv_data = json.load(fh)
+            except Exception as exc:
+                print(f'Failed to read inventory: {exc}')
+                continue
+            items = parse_inventory(inv_data)
+            if not items:
+                print('No tradable items found.')
+                continue
+            print(f'Found {len(items)} items. Querying prices...')
+            for name, wear in items:
+                filters = {'include_auctions': False}
+                if wear:
+                    filters['wear'] = wear
+                res = fetch_lowest_listing(key, name, filters)
+                if res:
+                    price = res['price_usd']
+                    url = res['url']
+                    print(f"{name} ({wear or 'Any'}): ${price:.2f} - {url}")
+                else:
+                    print(f"{name} ({wear or 'Any'}): no listing found")
+                time.sleep(rate_limit_interval())
         elif action == '0':
             logger.info('User exited application')
             break

--- a/src/csfloat_price_checker/inventory.py
+++ b/src/csfloat_price_checker/inventory.py
@@ -1,0 +1,77 @@
+"""Helpers for loading Steam inventory dumps."""
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+# Map full wear names to abbreviated codes used by CSFloat API
+WEAR_ABBREVIATIONS = {
+    "Factory New": "FN",
+    "Minimal Wear": "MW",
+    "Field-Tested": "FT",
+    "Well-Worn": "WW",
+    "Battle-Scarred": "BS",
+}
+
+# Substrings that identify items which should be ignored when processing an
+# inventory.  These include badges, medals, coins and other non-marketable
+# collectibles that the user does not want priced.
+IGNORED_TYPES = [
+    "badge",
+    "medal",
+    "coin",
+    "collectible",
+    "music kit",
+    "graffiti",
+    "charm",
+]
+
+
+def _is_ignored(item: Dict) -> bool:
+    """Return ``True`` if the item should be ignored based on its type."""
+    item_type = str(item.get("type", "")).lower()
+    return any(sub in item_type for sub in IGNORED_TYPES)
+
+
+def _extract_wear(tags: List[Dict]) -> str | None:
+    """Extract the wear code (FN/MW/FT/WW/BS) from a tag list."""
+    for tag in tags:
+        if tag.get("category") == "Exterior":
+            full = tag.get("localized_tag_name")
+            return WEAR_ABBREVIATIONS.get(full)
+    return None
+
+
+def parse_inventory(data: Dict) -> List[Tuple[str, str | None]]:
+    """Parse a Steam inventory JSON dump.
+
+    Parameters
+    ----------
+    data:
+        The deserialised inventory JSON with ``assets`` and ``descriptions``
+        sections as provided by the Steam API.
+
+    Returns
+    -------
+    list
+        A list of ``(market_hash_name, wear)`` tuples.  Items whose type
+        matches entries in :data:`IGNORED_TYPES` are skipped.
+    """
+
+    assets = data.get("assets", [])
+    descriptions = data.get("descriptions", [])
+    desc_map = {(d.get("classid"), d.get("instanceid")): d for d in descriptions}
+
+    items: List[Tuple[str, str | None]] = []
+    for asset in assets:
+        key = (asset.get("classid"), asset.get("instanceid"))
+        desc = desc_map.get(key)
+        if not desc:
+            continue
+        if _is_ignored(desc):
+            continue
+        name = desc.get("market_hash_name") or desc.get("name")
+        if not name:
+            continue
+        wear = _extract_wear(desc.get("tags", []))
+        items.append((name, wear))
+    return items


### PR DESCRIPTION
## Summary
- allow the CLI to price items from a Steam inventory JSON file
- parse inventory dumps, ignoring badges and other collectibles
- document new inventory pricing feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68978f4fe9bc832cbd4443648fd248b1